### PR TITLE
qemu-test: move qemu comand line to nix configuration:

### DIFF
--- a/pkgs/initrd-creator/lib/qemu-test
+++ b/pkgs/initrd-creator/lib/qemu-test
@@ -2,16 +2,8 @@
 
 set cpus 1
 set kernel [lindex $argv 0]
-set kernel $::env(kernelFile)
-set initrd $::env(initrd)
-set cmdline $::env(linuxCmd)
 set timeoutSeconds $::env(timeoutSeconds)
-
-set qemuArgs "-machine q35,accel=kvm -m 2048 -nographic -net none -no-reboot -cpu host,+vmx -kernel $kernel -initrd $initrd"
-
-if {$cmdline != ""} {
-    append qemuArgs " -append $cmdline"
-}
+set qemuArgs $::env(qemuArgs)
 
 eval spawn qemu-system-x86_64 $qemuArgs
 

--- a/pkgs/initrd-creator/lib/qemu-test.nix
+++ b/pkgs/initrd-creator/lib/qemu-test.nix
@@ -5,16 +5,22 @@ pkgs:
   timeoutSeconds ? 600
 }:
 let
-  linuxCmd = "\"console=ttyS0 root=/dev/ram rw\"";
+  qemuString = pkgs.lib.concatStringsSep " " [
+    "-machine q35,accel=kvm"
+    "-m 2048"
+    "-nographic"
+    "-net none"
+    "-no-reboot"
+    ''-kernel "${pkgs.linuxPackages_latest.kernel}/bzImage"''
+    ''-append "console=ttyS0 root=/dev/ram rw"''
+  ];
 in pkgs.runCommandNoCC "initrd-tests" {
   nativeBuildInputs = with pkgs; [
     qemu
     expect
   ];
 
-  kernelFile = "${pkgs.linuxPackages_latest.kernel}/bzImage";
-  inherit initrd;
-  inherit linuxCmd;
+  qemuArgs = qemuString + " -initrd ${initrd}";
   inherit timeoutSeconds;
 } ''
   cp ${./qemu-test} qemu-test


### PR DESCRIPTION
Currently the Qemu configuration is very static except the kernel, append and initrd parameters.
This MR makes the complete Qemu command line configurable by the nix expression.

That enables the user to configure Qemu to  its needs.