### PR TITLE
qemu-test: increase main memory size

### DIFF
--- a/pkgs/initrd-creator/lib/qemu-test
+++ b/pkgs/initrd-creator/lib/qemu-test
@@ -7,7 +7,7 @@ set initrd $::env(initrd)
 set cmdline $::env(linuxCmd)
 set timeoutSeconds $::env(timeoutSeconds)
 
-set qemuArgs "-machine q35,accel=kvm -m 2048 -nographic -net none -no-reboot -cpu host,+vmx -kernel $kernel -initrd $initrd"
+set qemuArgs "-machine q35,accel=kvm -m 4096 -nographic -net none -no-reboot -cpu host,+vmx -kernel $kernel -initrd $initrd"
 
 if {$cmdline != ""} {
     append qemuArgs " -append $cmdline"


### PR DESCRIPTION
Currently we boot a kernel and initrd in QEMU with 2 Gigabytes of main memory.

We run in some  trouble with initrd's with size larger than 250 MB compressed and 750MB uncompressed.

This MR increases the main memory that is passed to QEMU to 4 Gigabytes to boot larger initrd images.