### PR TITLE
expect: update script for simpler use

### DIFF
--- a/pkgs/initrd-creator/lib/qemu-test
+++ b/pkgs/initrd-creator/lib/qemu-test
@@ -7,10 +7,10 @@ set initrd $::env(initrd)
 set cmdline $::env(linuxCmd)
 set timeoutSeconds $::env(timeoutSeconds)
 
-set qemuArgs "-machine q35,accel=kvm -m 4096 -nographic -net none -no-reboot -cpu host,+vmx -kernel $kernel -initrd $initrd"
+set qemuArgs "-machine q35,accel=kvm -m 4096 -nographic -net none -no-reboot -cpu host,+vmx -kernel \"$kernel\" -initrd \"$initrd\""
 
 if {$cmdline != ""} {
-    append qemuArgs " -append $cmdline"
+    append qemuArgs " -append \"$cmdline\""
 }
 
 eval spawn qemu-system-x86_64 $qemuArgs


### PR DESCRIPTION
Currently, we have to pass ticks in the initrd string when there are spaces in it.

This MR circumvents this issue as it moves the tick encapsulation to the expect script.