### PR TITLE
qemu-test: remove additional ticks in command line configuration

### DIFF
--- a/pkgs/initrd-creator/lib/qemu-test.nix
+++ b/pkgs/initrd-creator/lib/qemu-test.nix
@@ -5,7 +5,7 @@ pkgs:
   timeoutSeconds ? 600
 }:
 let
-  linuxCmd = "\"console=ttyS0 root=/dev/ram rw\"";
+  linuxCmd = "console=ttyS0 root=/dev/ram rw";
 in pkgs.runCommandNoCC "initrd-tests" {
   nativeBuildInputs = with pkgs; [
     qemu


### PR DESCRIPTION
Currently the test initrd build fails, because of some additional ticks that aren't removed in the last MR.

This MR removes the additional ticks that leads to the failing tests.