### PR TITLE
qemu-tests: make qemu arguments more configureable

### DIFF
--- a/pkgs/initrd-creator/lib/qemu-test
+++ b/pkgs/initrd-creator/lib/qemu-test
@@ -6,8 +6,9 @@ set kernel $::env(kernelFile)
 set initrd $::env(initrd)
 set cmdline $::env(linuxCmd)
 set timeoutSeconds $::env(timeoutSeconds)
+set qemuArgs $::env(qemuArguments)
 
-set qemuArgs "-machine q35,accel=kvm -m 4096 -nographic -net none -no-reboot -cpu host,+vmx -kernel \"$kernel\" -initrd \"$initrd\""
+append qemuArgs " -kernel \"$kernel\" -initrd \"$initrd\""
 
 if {$cmdline != ""} {
     append qemuArgs " -append \"$cmdline\""

--- a/pkgs/initrd-creator/lib/qemu-test.nix
+++ b/pkgs/initrd-creator/lib/qemu-test.nix
@@ -1,21 +1,23 @@
 pkgs:
 
-{
-  initrd,
-  timeoutSeconds ? 600
-}:
+{ initrd, timeoutSeconds ? 600 }:
 let
   linuxCmd = "console=ttyS0 root=/dev/ram rw";
-in pkgs.runCommandNoCC "initrd-tests" {
-  nativeBuildInputs = with pkgs; [
-    qemu
-    expect
+  qemuArguments = pkgs.lib.concatStringsSep " " [
+    "-machine q35,accel=kvm"
+    "-m 4096"
+    "-nographic"
+    "-net none"
+    "-no-reboot"
   ];
+in pkgs.runCommandNoCC "initrd-tests" {
+  nativeBuildInputs = with pkgs; [ qemu expect ];
 
   kernelFile = "${pkgs.linuxPackages_latest.kernel}/bzImage";
   inherit initrd;
   inherit linuxCmd;
   inherit timeoutSeconds;
+  inherit qemuArguments;
 } ''
   cp ${./qemu-test} qemu-test
   patchShebangs qemu-test
@@ -24,5 +26,5 @@ in pkgs.runCommandNoCC "initrd-tests" {
    mkdir -p $out/nix-support
    cp output.log $out/
    echo "report testlog $out output.log" > $out/nix-support/hydra-build-products
-  ''
+''
 


### PR DESCRIPTION
Currently, there is no way to specify QEMU configuration options from outside the test script.

This PR makes the test runs dynamically configurable from different tests.