### PR TITLE
Flush URL to console while waiting in run_sotest

### DIFF
--- a/pkgs/run-sotest/src/run_sotest/__main__.py
+++ b/pkgs/run-sotest/src/run_sotest/__main__.py
@@ -106,7 +106,10 @@ def main():
         raise Exception("Either --poll or --nopoll must be used.")
 
     tr_id = create_test_run(cmdline_args)
-    print("{}/results/{}".format(cmdline_args.sotest_url, tr_id))
+
+    # Flush output of the URL, so users see the URL while waiting.
+    print("{}/results/{}".format(cmdline_args.sotest_url, tr_id), flush=True)
+
     if cmdline_args.poll:
         poll_test_run(cmdline_args.sotest_url, tr_id)
 


### PR DESCRIPTION
Users of run_sotest used to run it with `python -u` to get unbuffered output and see the sotest URL while the script kept polling for results. Handle this in the script itself by manual flushing.