### PR TITLE
makeInitrd: Add support for prepend

### DIFF
--- a/lib/patched-make-initrd.nix
+++ b/lib/patched-make-initrd.nix
@@ -6,7 +6,7 @@
 
 { pkgs }:
 
-{ initScript, additionalContents ? [], name ? "initrd", pathPkgs ? [] }:
+{ initScript, additionalContents ? [], name ? "initrd", pathPkgs ? [], prepend ? [] }:
 
 let
   fileSizeList = pkgs.writeText "stats.sh" ''
@@ -56,4 +56,4 @@ let
     object = initScriptFrame;
     symlink = "/init";
   } ];
-in (f { inherit name; contents = initScriptContent ++ additionalContents; }) // { timeoutSeconds = 60; }
+in (f { inherit name prepend; contents = initScriptContent ++ additionalContents; }) // { timeoutSeconds = 60; }


### PR DESCRIPTION
This allows us to build ramdisks with microcode updates attached to them.