### PR TITLE
sotest lib: generate zip bundle from test run description closure

### DIFF
--- a/lib/sotest.nix
+++ b/lib/sotest.nix
@@ -3,30 +3,90 @@
 with pkgs.lib;
 
 rec {
-  projectConfigJSON = {
-      boot_prerequisites ? [],
-      extra_dependencies ? [],
-      boot_panic_patterns ? [],
-      boot_items ? []
+  # Create an attribute set of a sotest test run with the format specified in
+  # https://docs.sotest.io/project_config
+  # In order to upload it to a sotest instance, it should be converted to
+  # JSON or YAML, see `asJSONFile` and `asYAMLFile`.
+  projectConfigJSON =
+    { boot_prerequisites ? []
+    , extra_dependencies ? []
+    , boot_panic_patterns ? []
+    , boot_items ? []
     }: builtins.toJSON {
       inherit
         boot_items
         boot_panic_patterns
         boot_prerequisites
-        extra_dependencies;
+        extra_dependencies
+        ;
     };
+
+  # Create a pretty-printed JSON file from the input
   asJSONFile = jsonContent: pkgs.runCommandNoCC "content.json"
     { nativeBuildInputs = [ pkgs.jq ]; }
     "jq '.' ${pkgs.writeText "content.json" jsonContent} > $out";
+
+  # Create a pretty-printed YAML file from the input
   asYAMLFile = jsonContent: pkgs.runCommandNoCC "content.yaml"
     { nativeBuildInputs = [ pkgs.yq ]; }
     "yq -y '.' ${pkgs.writeText "content.yaml" jsonContent} > $out";
-  linuxBootItem = {
-      boot_item_timeout ? 300,
-      name,
-      kernel,
-      kernelParams ? [ "console=@{linux_terminal}" ],
-      initrd
+
+  # Calculate list of direct dependencies of a derivation
+  flatReferences = drv: pkgs.stdenv.mkDerivation {
+    name = "flat-closure-info";
+    __structuredAttrs = true;
+    exportReferencesGraph.closure = [ drv ];
+    PATH = "${pkgs.jq}/bin";
+    builder = builtins.toFile "builder" ''
+      . .attrs.sh
+      jq -r '.exportReferencesGraph.closure[0] as $x | .closure[] | select(.path == $x) | .references[]' \
+        < .attrs.json \
+        > ''${outputs[out]}
+    '';
+  };
+
+  # Generate a ZIP bundle that contains all direct dependencies of a derivation
+  # In case any of these deps have runtime deps themselves, this will *not* work!
+  zipBundleFromTestrunClosure = drv: pkgs.runCommandNoCC "${drv.name}-bundle.zip" {} ''
+    cd /nix/store
+    paths=""
+    for path in $(cat ${flatReferences drv}); do
+      paths="$paths $(basename $path)"
+    done
+    ${pkgs.zip}/bin/zip -r $out --names-stdin <<< ''${paths// /$'\n'}
+  '';
+
+  # Pick a subset of paths from within a derivation and create a new derivation
+  # that links to only these paths.
+  # This can be used to reduce the size of a derivation if only parts of it are
+  # needed.
+  pickSubPaths = paths: drv: pkgs.runCommandNoCC "${drv.name}-selection" { inherit paths; } ''
+    mkdir $out
+    for path in $paths; do
+      mkdir -p "$out/$(dirname $path)"
+      ln -s "${drv}/$path" "$out/$path"
+    done
+  '';
+
+  # Given a test run document, generate a derivation that contains both an
+  # automatically generated ZIP bundle containing all dependencies as well as
+  # the test run document with corrected paths that match the ZIP bundle's
+  # content.
+  projectBundleFromTestrunClosure = testrunDoc: pkgs.runCommandNoCC "${testrunDoc.name}-sotest-bundle" {} ''
+    mkdir $out
+    ln -sf ${zipBundleFromTestrunClosure testrunDoc} $out/bundle.zip
+    FILE=${testrunDoc}
+    sed 's#/nix/store/##g' ${testrunDoc} > $out/project-config.''${FILE##*.}
+  '';
+
+  # This is a simple helper function that creates a standard boot item for
+  # sotest from a kernel-ramdisk pair
+  linuxBootItem =
+    { boot_item_timeout ? 300
+    , name
+    , kernel
+    , kernelParams ? [ "console=@{linux_terminal}" ]
+    , initrd
     }: {
       inherit boot_item_timeout name;
       exec = builtins.concatStringsSep " " ([ kernel ] ++ kernelParams);

--- a/pkgs/sotest-testruns/default.nix
+++ b/pkgs/sotest-testruns/default.nix
@@ -1,55 +1,22 @@
 { cbsLib, pkgs, initrds, kernels }:
 
 with pkgs.lib;
-with cbsLib.sotest;
 
 let
-  copyInitrds = builtins.concatStringsSep ";" (mapAttrsToList
-    (name: path: "cp ${path}/initrd ${name}.initrd")
-    initrds);
-
-  # instead of linux and linux_latest use linux-1.2.3
-  kernels' = mapAttrs'
-    (_: kernelDrv: nameValuePair kernelDrv.name kernelDrv)
-    kernels;
-  copyKernels = builtins.concatStringsSep ";" (mapAttrsToList
-    (name: drv: "cp ${drv}/bzImage ${name}.bzImage")
-    kernels);
-
-  kernels'' = mapAttrs (name: _: "${name}.bzImage") kernels';
-  initrds' = mapAttrs (name: _: "${name}.initrd") initrds;
-
-  merge = builtins.foldl' (l: r: l // r) {};
-  pairs = merge (mapAttrsToList (kernelName: kernel:
-      mapAttrs' (initrdName: initrd:
-        nameValuePair
-          ("Kernel " + kernelName + ", initrd " + initrdName)
-          { inherit kernel initrd; }
-      ) initrds'
-    ) kernels'');
-  boot_items = mapAttrsToList
-    (name: content: linuxBootItem {
-      inherit name;
-      inherit (content) kernel initrd;
-    })
-    pairs;
-  projectConfig = projectConfigJSON { inherit boot_items; };
-  linux-tests = pkgs.stdenv.mkDerivation {
-    name = "sotest-testrun";
-    src = ./.;
-
-    nativeBuildInputs = with pkgs; [ zip ];
-
-    installPhase = ''
-      ${copyInitrds}
-      ${copyKernels}
-
-      mkdir $out
-      zip $out/binaries.zip *.initrd *.bzImage
-      cp ${asJSONFile projectConfig} $out/projectconfig.json
-      cp ${asYAMLFile projectConfig} $out/projectconfig.yaml
-    '';
-  };
+  pickOnlyKernel = cbsLib.sotest.pickSubPaths ["bzImage"];
+  combinations = cbsLib.cartesian.cartesianProductFromSet {
+      initrd = builtins.attrValues initrds;
+      kernel = builtins.attrValues kernels;
+    };
+  projectConf = let
+    f = { initrd, kernel }: cbsLib.sotest.linuxBootItem {
+      kernel = "${pickOnlyKernel kernel}/bzImage";
+      initrd = "${initrd}/initrd";
+      name = "Kernel ${kernel.name} initrd ${initrd.name}";
+    };
+  in cbsLib.sotest.asJSONFile (cbsLib.sotest.projectConfigJSON {
+    boot_items = builtins.map f combinations;
+  });
 in {
-  inherit linux-tests;
+  linux-tests = cbsLib.sotest.projectBundleFromTestrunClosure projectConf;
 }


### PR DESCRIPTION
Previously we had nix (or in other projects python) code that generates both a sotest project config and a zip bundle in parallel. In the end, both had to work together.

This pull requests extends the sotest library in a way that you can now:

- create a sotest project config that uses nix store paths to reference binaries
- run this through the `projectBundleFromTestrunClosure` function and automatically get the zip bundle and an adapted project config that works with this zip file.

you can see the working result here: https://opensource.sotest.io/results/83

i also gave the initrds descriptive names, that is not yet visible in the sotest test run.