### PR TITLE
default.nix: Export overlays

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,5 +9,6 @@
 
 {
   inherit pkgs;
+  inherit (ovl) overlays;
   nixpkgs = sources.nixpkgs;
 }


### PR DESCRIPTION
The overlays list itself needs to be exported so it can be used as overlays over nixpkgs like so:
```nix
let
  pkgs = import nixpkgs { overlays = (import cbspkgs {}).overlays; };
in pkgs.hello
```