### PR TITLE
Allow external files in shellcheck

### DIFF
--- a/lib/writers.nix
+++ b/lib/writers.nix
@@ -7,7 +7,7 @@
   writeBashScript = pkgs.writers.makeScriptWriter {
     interpreter = "${pkgs.bash}/bin/bash";
     check = pkgs.writeShellScript "shellcheck.sh" ''
-      ${pkgs.shellcheck}/bin/shellcheck "$1"
+      ${pkgs.shellcheck}/bin/shellcheck --external-sources "$1"
     '';
   };
 }


### PR DESCRIPTION
Currently, shellcheck fails with error code SC1091 when sourcing a file that is not in the FILES environment variable of shellcheck.
This PR allows files that are not listed in the FILES environment variable.