### PR TITLE
Export nixos modules

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,4 +1,3 @@
-{ niv }:
 {
   cyberus = {
     certificateAuthority = import ./cyberus-ca.nix;

--- a/nix/cyberus-overlay-function.nix
+++ b/nix/cyberus-overlay-function.nix
@@ -21,7 +21,7 @@ let
     passthrough = attrName: {
       "${attrName}" = (super.cbspkgs."${attrName}" or {}) // (current."${attrName}" or {});
     };
-    extraAttrs = builtins.foldl' (l: r: l // passthrough r) {} ["lib" "sotests" "tests"];
+    extraAttrs = builtins.foldl' (l: r: l // passthrough r) {} ["lib" "nixosModules" "sotests" "tests"];
   in
     {
       cbspkgs = (super.cbspkgs or {} // current) // extraAttrs;

--- a/nix/cyberus-overlay.nix
+++ b/nix/cyberus-overlay.nix
@@ -9,8 +9,10 @@ let
   };
   kernelSet = import ../pkgs/kernels { pkgs = self; };
 
+  nixosModules = import ../modules;
+
 in {
-  inherit lib;
+  inherit lib nixosModules;
 
   bender = super.callPackage sources.bender {};
 


### PR DESCRIPTION
in order to have access to modules that each of our projects exports in one uniform way, i added `pkgs.cbspkgs.nixosModules` merging. 