### PR TITLE
Make kernel compile initrd run with NixOS 21.05's linux kernel version

### DIFF
--- a/pkgs/initrd-creator/image_defs/kernel-compile-initrd.nix
+++ b/pkgs/initrd-creator/image_defs/kernel-compile-initrd.nix
@@ -9,6 +9,7 @@
   cbsLib,
   coreutils,
   diffutils,
+  elfutils,
   fetchurl,
   findutils,
   flex,
@@ -33,7 +34,7 @@
 }:
 
 let
-  hostLibPackages = [ libelf openssl ];
+  hostLibPackages = [ elfutils libelf openssl ];
 
   joinStrings = f: l: builtins.concatStringsSep ":" (map f l);
   includeFlags = joinStrings (x: "${lib.getDev x}/include") hostLibPackages;
@@ -68,6 +69,10 @@ in (cbsLib.makeInitrd {
     # Most shellscripts in the kernel source code need this
     mkdir /bin
     ln -sf ${bash}/bin/bash /bin/sh
+
+    # linux kernel repo's scripts/ld-version.sh needs this
+    mkdir -p /usr/bin
+    ln -sf ${gawk}/bin/awk /usr/bin/awk
 
     # At some point the kernel's build system will want to create files here
     mkdir /tmp


### PR DESCRIPTION
when this repository is run on basis of nixos 21.05, then a linux kernel 5.10 is built which comes with new include dependencies.

this issue uncovered the same problem: https://github.com/NixOS/nixpkgs/issues/91609

this PR puts the suggested fix in place. i tried this on top of nixos 20.09 and 21.05 and both works.
(the internal MR on our private cbspkgs shows the latter)