### PR TITLE
lib: Add mkProjectBundle

### DIFF
--- a/lib/sotest.nix
+++ b/lib/sotest.nix
@@ -94,4 +94,63 @@ rec {
       exec = builtins.concatStringsSep " " ([ kernel ] ++ kernelParams);
       load = [ initrd ];
     };
+
+  # Given a test run attribute set, this function is used to build a bundle consisting of a project
+  # config in YAML format, and a ZIP archive containing exactly the referenced test files.  THe YAML
+  # file is generated via builtins.toJSON from the test run attribute set. Check
+  # https://docs.sotest.io/user/project_config for the exact format.
+  #
+  # This function will only work for test run descriptions that exclusively use content of the nix
+  # store for their `exec`, `load`, and `extra_files` attributes. Only paths at the beginning of
+  # such an attribute will be included in the resulting zip archive. In particular, a boot item with
+  # an entry like
+  #
+  # exec = "/nix/store/<hash>-linux/bzImage init=/nix/store/<hash>-linux-system/init";
+  #
+  # will NOT cause /nix/store/<hash>-linux-system/init to be included in the zip archive. The
+  # corresponding `exec` entry in the resulting YAML file will contain:
+  #
+  # exec: "<hash>-linux/bzImage init=/nix/store/<hash>-linux-system/init"
+  #
+  # Limitations:
+  #
+  # - The parsing logic for entries is limited to `pkgs.lib.splitString " "`, which is why this
+  #   function will not work correctly for paths that contain whitespace.
+  mkProjectBundle = testRunConfig:
+    let
+      # nixpkgs has a function `updateManyAttrsByPath`, which almost does what we need, but doesn't
+      # support optional attributes in the way we need it, which is why we write our own little
+      # helper here.
+      updateAttr = key: default: update: attrs: attrs // {
+        "${key}" = if builtins.hasAttr key attrs then update (builtins.getAttr key attrs) else default;
+      };
+      error = attrname: name:
+        throw "Missing required attribute \"${attrname}\" in boot item ${name}";
+      stripPrefixFromBootItem = boot_item:
+        updateAttr "exec" (error "exec" boot_item.name) (pkgs.lib.removePrefix "/nix/store/")
+          (updateAttr "load" [ ] (map (pkgs.lib.removePrefix "/nix/store/"))
+            (updateAttr "extra_files" [ ] (map (pkgs.lib.removePrefix "/nix/store/"))
+              boot_item
+            ));
+      collectEntries = boot_item: [ boot_item.exec ] ++ (boot_item.load or [ ]) ++ (boot_item.extra_files or [ ]);
+      strippedConfig = updateAttr "boot_items" [ ] (map stripPrefixFromBootItem) testRunConfig;
+      paths =
+        # splitString will always return a list with at least one element, which is why
+        # builtins.head is safe to use here.
+        map builtins.head
+          (map (pkgs.lib.strings.splitString " ")
+            (builtins.concatMap collectEntries strippedConfig.boot_items));
+      configYaml = asYAMLFile (builtins.toJSON strippedConfig);
+    in
+    pkgs.runCommandNoCC "sotest-bundle"
+      {
+        preferLocalBuild = true;
+        nativeBuildInputs = [ pkgs.zip ];
+      } ''
+      mkdir $out
+      cp ${configYaml} $out/project-config.yaml
+      cd /nix/store
+      paths="${builtins.concatStringsSep " " paths}"
+      zip -r $out/bundle.zip --names-stdin <<< ''${paths// /$'\n'}
+    '';
 }

--- a/lib/sotest.nix
+++ b/lib/sotest.nix
@@ -74,12 +74,15 @@ rec {
   # automatically generated ZIP bundle containing all dependencies as well as
   # the test run document with corrected paths that match the ZIP bundle's
   # content.
-  projectBundleFromTestrunClosure = testrunDoc: pkgs.runCommandNoCC "${testrunDoc.name}-sotest-bundle" {} ''
-    mkdir $out
-    ln -sf ${zipBundleFromTestrunClosure testrunDoc} $out/bundle.zip
-    FILE=${testrunDoc}
-    sed 's#/nix/store/##g' ${testrunDoc} > $out/project-config.''${FILE##*.}
-  '';
+  projectBundleFromTestrunClosure = pkgs.lib.warn
+    ("Using projectBundleFromTestrunClosure is deprecated. " ++
+      "Use mkProjectBundle instead.")
+    (testrunDoc: pkgs.runCommandNoCC "${testrunDoc.name}-sotest-bundle" { } ''
+      mkdir $out
+      ln -sf ${zipBundleFromTestrunClosure testrunDoc} $out/bundle.zip
+      FILE=${testrunDoc}
+      sed 's#/nix/store/##g' ${testrunDoc} > $out/project-config.''${FILE##*.}
+    '');
 
   # This is a simple helper function that creates a standard boot item for
   # sotest from a kernel-ramdisk pair

--- a/lib/sotest.nix
+++ b/lib/sotest.nix
@@ -4,7 +4,7 @@ with pkgs.lib;
 
 rec {
   # Create an attribute set of a sotest test run with the format specified in
-  # https://docs.sotest.io/project_config
+  # https://docs.sotest.io/user/project_config
   # In order to upload it to a sotest instance, it should be converted to
   # JSON or YAML, see `asJSONFile` and `asYAMLFile`.
   projectConfigJSON =


### PR DESCRIPTION
The existing `projectBundleFromTestrunClosure` functionality used for creating project bundles from a nix expression has a few disadvantages:

1. It is a bit overeager in choosing which paths to include in the zip archive (#33)
2. It strips the `/nix/store` prefix unconditionally from all referenced paths, even ones that should not be changed  (#26)
3. Its interface is a bit weird, taking a derivation, while you would expect to be able to use it like this:
   `projectBundleFromTestrunClosure { boot_items: [ ... ]; tags: [ ... ]; }`.

This PR introduces a new function `mkProjectBundle`, which solves these issues:

Only paths referenced at the start of a `boot_item`'s `exec`, load`, or `extra_files` entries are included in the ZIP archive, and only these paths are changed in the resulting `project-config.yaml`, which fixes both #33 and #26. I've also taken the opportunity to have this function take an attribute set as the parameter, in contrast of a complete derivation. 

Using `mkProjectBundle` over the existing `projectBundleFromTestrunClosure` reduces the size of ZIP archives by ~50% for test runs that reference linux kernels and NixOS squashfs files, since all the other files of these large derivations are no longer part of the ZIP archive. 

I have added a deprecation warning to `projectBundleFromTestrunClosure`, and intend to remove the deprecated functionality as soon as all of our internal projects have switched over to the new way of creating bundles.
 