### PR TITLE
lib: fix string concatenation in deprecation warning

### DIFF
--- a/lib/sotest.nix
+++ b/lib/sotest.nix
@@ -75,7 +75,7 @@ rec {
   # the test run document with corrected paths that match the ZIP bundle's
   # content.
   projectBundleFromTestrunClosure = pkgs.lib.warn
-    ("Using projectBundleFromTestrunClosure is deprecated. " ++
+    ("Using projectBundleFromTestrunClosure is deprecated. " +
       "Use mkProjectBundle instead.")
     (testrunDoc: pkgs.runCommandNoCC "${testrunDoc.name}-sotest-bundle" { } ''
       mkdir $out


### PR DESCRIPTION
#34 contained a bug in the newly introduced deprecation warning, which breaks our internal pipelines.

In particular, this happens:

```
$ nix-env -f default.nix -i run-sotest
error: value is a string while a list was expected, at /path/to/cbspkgs-public/lib/sotest.nix:78:6
(use '--show-trace' to show detailed location information)
```

These changes fix the problem:

```
$ nix-env -f default.nix -i run-sotest
trace: warning: Using projectBundleFromTestrunClosure is deprecated. Use mkProjectBundle instead.
replacing old 'run-sotest-1.0.0'
installing 'run-sotest-1.0.0'
```