### PR TITLE
run_sotest: Use new results link at `test_runs`

### DIFF
--- a/pkgs/run-sotest/src/run_sotest/__main__.py
+++ b/pkgs/run-sotest/src/run_sotest/__main__.py
@@ -108,7 +108,7 @@ def main():
     tr_id = create_test_run(cmdline_args)
 
     # Flush output of the URL, so users see the URL while waiting.
-    print("{}/results/{}".format(cmdline_args.sotest_url, tr_id), flush=True)
+    print("{}/test_runs/{}".format(cmdline_args.sotest_url, tr_id), flush=True)
 
     if cmdline_args.poll:
         poll_test_run(cmdline_args.sotest_url, tr_id)


### PR DESCRIPTION
SoTest now uses new routes for accessing test run results, this switches the displayed route from `/results/` to `/test_runs/`.