### PR TITLE
Switch run_sotest to new Web UI API routes

### DIFF
--- a/pkgs/run-sotest/default.nix
+++ b/pkgs/run-sotest/default.nix
@@ -2,7 +2,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "run-sotest";
-  version = "1.0.0";
+  version = "1.1.0";
 
   src = ./src;
 


### PR DESCRIPTION
This PR switches the `run_sotest` script over to the new SoTest API layout and therefore gets rid of the old `/api/` routes.

The new version of `/api/query`, `/test_runs/<id>/status` now returns an HTTP 400 status code when the Test Run could not be found.

The version number has been increased to `1.1.0`, although I'm not sure if there are any additional consequences of that change.

There's an internal MR with an integration test for the new script as well that's been executed with these changes.