### PR TITLE
Remove old sotest package creation functionality

### DIFF
--- a/lib/sotest.nix
+++ b/lib/sotest.nix
@@ -8,11 +8,11 @@ rec {
   # In order to upload it to a sotest instance, it should be converted to
   # JSON or YAML, see `asJSONFile` and `asYAMLFile`.
   projectConfigJSON =
-    { boot_prerequisites ? []
-    , extra_dependencies ? []
-    , boot_panic_patterns ? []
-    , boot_items ? []
-    , local_tags_list ? []
+    { boot_prerequisites ? [ ]
+    , extra_dependencies ? [ ]
+    , boot_panic_patterns ? [ ]
+    , boot_items ? [ ]
+    , local_tags_list ? [ ]
     }: builtins.toJSON {
       inherit
         boot_items
@@ -32,57 +32,6 @@ rec {
   asYAMLFile = jsonContent: pkgs.runCommandNoCC "content.yaml"
     { nativeBuildInputs = [ pkgs.yq ]; }
     "yq -y '.' ${pkgs.writeText "content.yaml" jsonContent} > $out";
-
-  # Calculate list of direct dependencies of a derivation
-  flatReferences = drv: pkgs.stdenv.mkDerivation {
-    name = "flat-closure-info";
-    __structuredAttrs = true;
-    exportReferencesGraph.closure = [ drv ];
-    PATH = "${pkgs.jq}/bin";
-    builder = builtins.toFile "builder" ''
-      . .attrs.sh
-      jq -r '.exportReferencesGraph.closure[0] as $x | .closure[] | select(.path == $x) | .references[]' \
-        < .attrs.json \
-        > ''${outputs[out]}
-    '';
-  };
-
-  # Generate a ZIP bundle that contains all direct dependencies of a derivation
-  # In case any of these deps have runtime deps themselves, this will *not* work!
-  zipBundleFromTestrunClosure = drv: pkgs.runCommandNoCC "${drv.name}-bundle.zip" {} ''
-    cd /nix/store
-    paths=""
-    for path in $(cat ${flatReferences drv}); do
-      paths="$paths $(basename $path)"
-    done
-    ${pkgs.zip}/bin/zip -r $out --names-stdin <<< ''${paths// /$'\n'}
-  '';
-
-  # Pick a subset of paths from within a derivation and create a new derivation
-  # that links to only these paths.
-  # This can be used to reduce the size of a derivation if only parts of it are
-  # needed.
-  pickSubPaths = paths: drv: pkgs.runCommandNoCC "${drv.name}-selection" { inherit paths; } ''
-    mkdir $out
-    for path in $paths; do
-      mkdir -p "$out/$(dirname $path)"
-      ln -s "${drv}/$path" "$out/$path"
-    done
-  '';
-
-  # Given a test run document, generate a derivation that contains both an
-  # automatically generated ZIP bundle containing all dependencies as well as
-  # the test run document with corrected paths that match the ZIP bundle's
-  # content.
-  projectBundleFromTestrunClosure = pkgs.lib.warn
-    ("Using projectBundleFromTestrunClosure is deprecated. " +
-      "Use mkProjectBundle instead.")
-    (testrunDoc: pkgs.runCommandNoCC "${testrunDoc.name}-sotest-bundle" { } ''
-      mkdir $out
-      ln -sf ${zipBundleFromTestrunClosure testrunDoc} $out/bundle.zip
-      FILE=${testrunDoc}
-      sed 's#/nix/store/##g' ${testrunDoc} > $out/project-config.''${FILE##*.}
-    '');
 
   # This is a simple helper function that creates a standard boot item for
   # sotest from a kernel-ramdisk pair


### PR DESCRIPTION
This removes the deprecated functionality that has been replaced by the new function introduced in #34.

This PR contains in particular: 
- changing the sotest-testruns package to use the new functionality
- removing all the deprecated functionality from the sotest lib
- as a drive-by change, running nixpkgs-fmt on all changed nix files

[Here is our internal pipeline](https://gitlab.vpn.cyberus-technology.de/mnapierkowski/cbspkgs/-/pipelines/53164) for changes that bump all relevant repositories to the latest version, to ensure this PR doesn't remove any functionality that is still in use: 