### PR TITLE
run_sotest: Enable direct boot_files upload

### DIFF
--- a/pkgs/run-sotest/src/run_sotest/__main__.py
+++ b/pkgs/run-sotest/src/run_sotest/__main__.py
@@ -48,6 +48,11 @@ def parse_cmdline_args():
         default=0,
         help="Priority to be assigned to a test run. Jobs with numerically higher priority preempt lower-priority jobs. Can be negative, default = 0.",
     )
+    parser.add_argument(
+        "--testrun_id_file",
+        required=False,
+        help="File to store the created test run id in (overwrites any existing file).",
+    )
     return parser.parse_args()
 
 
@@ -91,6 +96,10 @@ def main():
 
     # Flush output of the URL, so users see the URL while waiting.
     print("{}/test_runs/{}".format(cmdline_args.sotest_url, tr_id), flush=True)
+
+    if cmdline_args.testrun_id_file:
+        with open(cmdline_args.testrun_id_file, "w") as fil:
+            fil.write(tr_id)
 
     if cmdline_args.poll:
         poll_test_run(cmdline_args.sotest_url, tr_id)

--- a/pkgs/run-sotest/src/run_sotest/__main__.py
+++ b/pkgs/run-sotest/src/run_sotest/__main__.py
@@ -20,7 +20,9 @@ def parse_cmdline_args():
     parser = argparse.ArgumentParser(description="Sotest Test Creator")
     parser.add_argument("sotest_url", help="Base URL to SoTest's web UI")
     parser.add_argument("sotest_config", help="Config with a list of boot items")
-    parser.add_argument("--boot_files", required=True, help="URL to an artifacts.zip")
+    parser.add_argument(
+        "--boot_files", required=True, help="URL or local path to an artifacts.zip"
+    )
     parser.add_argument(
         "--url", required=True, help="URL to be linked to in the web UI"
     )
@@ -54,12 +56,17 @@ def create_test_run(args):
     url = "{}/test_runs".format(args.sotest_url)
     files = {"config": open(args.sotest_config, "rb")}
     params = {
-        "boot_files_url": args.boot_files,
         "url": args.url,
         "user": args.user,
         "name": args.name,
         "priority": args.priority,
     }
+
+    # Check if boot files are a valid local path, assume URL otherwise
+    try:
+        files["boot_files"] = open(args.boot_files, "rb")
+    except:
+        params["boot_files_url"] = args.boot_files
 
     auth_user = os.environ.get("SOTEST_USER", None)
     auth_pass = os.environ.get("SOTEST_PASS", None)

--- a/pkgs/run-sotest/src/run_sotest/__main__.py
+++ b/pkgs/run-sotest/src/run_sotest/__main__.py
@@ -9,10 +9,10 @@ import argparse
 import os
 import requests
 import sys
-import time
+
+from .poll_test_run import poll_test_run
 
 HTTP_STATUS_OK = 200
-REQUEST_HEADERS = {"Accept": "application/json"}
 
 
 def parse_cmdline_args():
@@ -79,35 +79,6 @@ def create_test_run(args):
         sys.exit("Testrun Creation failed: {}".format(r.text))
 
     return r.text
-
-
-def query_test_run(sotest_url, testrun_id):
-    """Queries the status of a test run"""
-    url = "{}/test_runs/{}/status".format(sotest_url, testrun_id)
-    r = requests.get(url, headers=REQUEST_HEADERS)
-
-    if r.status_code != HTTP_STATUS_OK:
-        sys.exit("Testrun query failed: {}".format(r.text))
-
-    return r.json()
-
-
-def poll_test_run(sotest_url, testrun_id):
-    """Queries the status of a test run until it is no longer running and handles the result"""
-    while True:
-        result = query_test_run(sotest_url, testrun_id)
-        if result != "unfinished":
-            break
-        time.sleep(10)
-
-    if result == "success":
-        print("Test successful")
-    elif result == "fail":
-        sys.exit("Test failed")
-    elif result == "disabled":
-        sys.exit("Test has been aborted")
-    else:
-        sys.exit("Unexpected response: {}".format(result))
 
 
 def main():

--- a/pkgs/run-sotest/src/run_sotest/poll_app.py
+++ b/pkgs/run-sotest/src/run_sotest/poll_app.py
@@ -1,0 +1,33 @@
+#######################################
+#                                     #
+#  Copyright Cyberus Technology GmbH  #
+#           All rights reserved       #
+#                                     #
+#######################################
+
+import argparse
+
+from .poll_test_run import poll_test_run
+
+
+def parse_cmdline_args():
+    """Command line parsing"""
+    parser = argparse.ArgumentParser(description="Sotest Test Creator")
+    parser.add_argument("sotest_url", help="Base URL to SoTest's Web UI")
+    parser.add_argument("--id", required=True, help="ID of the SoTest Test Run")
+    return parser.parse_args()
+
+
+def main():
+    cmdline_args = parse_cmdline_args()
+
+    # Flush output of the URL, so users see the URL while waiting.
+    print(
+        "{}/test_runs/{}".format(cmdline_args.sotest_url, cmdline_args.id), flush=True
+    )
+
+    poll_test_run(cmdline_args.sotest_url, cmdline_args.id)
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/run-sotest/src/run_sotest/poll_test_run.py
+++ b/pkgs/run-sotest/src/run_sotest/poll_test_run.py
@@ -1,0 +1,42 @@
+#######################################
+#                                     #
+#  Copyright Cyberus Technology GmbH  #
+#           All rights reserved       #
+#                                     #
+#######################################
+
+import requests
+import sys
+import time
+
+HTTP_STATUS_OK = 200
+REQUEST_HEADERS = {"Accept": "application/json"}
+
+
+def query_test_run(sotest_url, testrun_id):
+    """Queries the status of a test run"""
+    url = "{}/test_runs/{}/status".format(sotest_url, testrun_id)
+    r = requests.get(url, headers=REQUEST_HEADERS)
+
+    if r.status_code != HTTP_STATUS_OK:
+        sys.exit("Testrun query failed: {}".format(r.text))
+
+    return r.json()
+
+
+def poll_test_run(sotest_url, testrun_id):
+    """Queries the status of a test run until it is no longer running and handles the result"""
+    while True:
+        result = query_test_run(sotest_url, testrun_id)
+        if result != "unfinished":
+            break
+        time.sleep(10)
+
+    if result == "success":
+        print("Test successful")
+    elif result == "fail":
+        sys.exit("Test failed")
+    elif result == "disabled":
+        sys.exit("Test has been aborted")
+    else:
+        sys.exit("Unexpected response: {}".format(result))

--- a/pkgs/run-sotest/src/setup.py
+++ b/pkgs/run-sotest/src/setup.py
@@ -8,5 +8,10 @@ setup(
     url="https://sotest.io/",
     description="A utility to schedule sotest test jobs",
     packages=["run_sotest"],
-    entry_points={"console_scripts": ["run_sotest = run_sotest.__main__:main"]},
+    entry_points={
+        "console_scripts": [
+            "run_sotest = run_sotest.__main__:main",
+            "poll_sotest = run_sotest.poll_app:main",
+        ]
+    },
 )


### PR DESCRIPTION
This adds some new parameters to enable users to upload boot files directly with the Test Run creation.

The parameter `boot_files` now accepts either a URL to some files or a file path to local files.

There's a new parameter `testrun_id_file`, which is a path to a file where the test run id is stored. This is needed for reliably exporting the test run id when no polling is used.

A new `poll_sotest` script that only polls a test run without requiring all of the parameters for test run creation. This script needs the test run id to work.

There's an internal integration test that uses the new script. I'd really appreciate some user feedback on how well this works both for pipeline and manual use. 