### PR TITLE
Use cartesian helper function from nixpkgs in sotest-testruns

### DIFF
--- a/pkgs/sotest-testruns/default.nix
+++ b/pkgs/sotest-testruns/default.nix
@@ -3,7 +3,7 @@
 with pkgs.lib;
 
 let
-  combinations = cbsLib.cartesian.cartesianProductFromSet {
+  combinations = cartesianProductOfSets {
     initrd = builtins.attrValues initrds;
     kernel = builtins.attrValues kernels;
   };


### PR DESCRIPTION
Our internal cartesian helper has been replaced with the offical one from nixpkgs in #40.
We missed once user of the function, causing `nix-build ./default.nix -A sotest-testruns.linux-tests` to fail.

Switch to the nixpkgs function to enable the build.